### PR TITLE
get_translations flag for multiple results

### DIFF
--- a/mstranslator.py
+++ b/mstranslator.py
@@ -131,10 +131,11 @@ class Translator(object):
                                contenttype, category)
 
     def get_translations(self, text, lang_from, lang_to, max_n=10, contenttype='text/plain', category='general',
-                         url=None, user=None, state=None):
+                         url=None, user=None, state=None, multi='true'):
         options = {
             'Category': category,
             'ContentType': contenttype,
+            'IncludeMultipleMTAlternatives': multi
         }
         if url:
             options['Uri'] = url


### PR DESCRIPTION
in get_translations():
'IncludeMultipleMTAlternatives': flag is 'false' by default, so the function is returning only 1 result regardless of the 'max_n' specified.
 Added the flag to the options and defaulted to 'true'